### PR TITLE
Change client invocation to use sudo. Move client.

### DIFF
--- a/security.md
+++ b/security.md
@@ -12,6 +12,14 @@ For some actions, Sira's workflow involves running commands on the control node.
 
 `sira-client` must be owned by `root:root` with `0700` permissions. As part of bootstrapping a node, you must give the user as whom Sira logs in (we'll call this **the Sira user**) permission to run `sira-client` via `sudo` without requiring a password. This is the only shell command that the control node runs directly on managed nodes; `sira-client` handles the rest. The Sira user requires no other special permissions; for instance, it *does not* need unrestricted `sudo` access.
 
+```
+# Example configuration (edit with visudo):
+
+# Allow <user> to run /opt/sira/bin/sira-client as root:root without entering a password.
+# Note that sudoers applies the last matched entry. If this user is already a sudoer, modify the existing entry instead.
+<user>  ALL=(root:root) NOPASSWD:/opt/sira/bin/sira-client
+```
+
 Funneling all local client actions through `sira-client` has at least two important security benefits. First, it provides access control: `sira-client` can verify that requested actions are actually authorized. (This is optional and is described below.) Second, it opens the smallest possible window through which to access administrative functions on managed nodes.
 
 Two alternatives to this scheme were considered and rejected:

--- a/src/run_plan/client.rs
+++ b/src/run_plan/client.rs
@@ -103,13 +103,14 @@ impl ClientInterface for Client {
 }
 
 impl Client {
-    /// Invoke `sira-client` on the remote host and pass it `yaml`.
+    /// Invoke `sudo /opt/sira/bin/sira-client <yaml> <signature>` on the remote host.
     async fn client_command(
         &mut self,
         yaml: &str,
         signature: Option<Vec<u8>>,
     ) -> Result<Output, openssh::Error> {
-        let mut command = self.session.command("sira-client");
+        let mut command = self.session.command("sudo");
+        command.arg("/opt/sira/bin/sira-client");
         command.arg(yaml);
         if let Some(sig) = signature {
             let sig = String::from_utf8(sig)


### PR DESCRIPTION
Change how sira invokes sira-client:
- When invoking sira-client, use sudo.
- Invoke the compile-time-static path: /opt/sira/bin/sira-client
- Implicitly require the Sira user to have passwordless sudo access to sira-client.

Also, add an example sudoers configuration to security.md.