### PR TITLE
Fix bug: platform-dependent upload behavior.

### DIFF
--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -416,9 +416,10 @@ pub enum Action {
 
         /// Whether to overwrite an existing file at [Action::Upload::to]. Defaults to `true`.
         ///
-        /// If `false`, this option causes Sira to invoke `mv -n` instead of `mv`. Sira's behavior
-        /// follows from your system's implementation of `mv -n`: most likely, in the event that a
-        /// file exists at the destination, Sira will silently decline to move the file.
+        /// Note that the file will be uploaded even if it ultimately will not be moved into place.
+        /// This allows Sira to most closely implement the expected behavior at the cost of some
+        /// bandwidth, transfer time, and disk activity. (If you feel Sira should make a different
+        /// trade-off, feel free to open an issue to state your case.)
         ///
         /// If this property is `false` and the file already exists, then the user, group, and
         /// permissions **will not be updated**. The existing file will remain untouched.


### PR DESCRIPTION
On some systems, mv -n, which we use for Action::Upload when overwrite is false, returns 0; on other systems, it returns a non-zero error exit. I was ignorant of this when I initially implemented the feature. I also did not know that the -n/--no-clobber feature was a non-POSIX extension with differing support across BSDs.

GNU CoreUtils has deprecated the -n/--no-clobber option we were using precisely because it has different exit behaviors across systems. Meanwhile, at time of writing, the replacement, --update=none, has not shipped to some current systems (such as Debian stable).

Thus, Sira now implements its own check for an existing file at the destination. This provides the added benefit of improving Sira's breadth of compatibility with non-GNU Unixes, though that remains untested.