### PR TITLE
Elide lifetimes that do not need names.

### DIFF
--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -433,7 +433,7 @@ pub enum Action {
 impl Serialize for Action {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         struct ExternallyTaggedAction<'a>(&'a Action);
-        impl<'a> Serialize for ExternallyTaggedAction<'a> {
+        impl Serialize for ExternallyTaggedAction<'_> {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 Action::serialize(self.0, serializer)
             }

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -253,7 +253,7 @@ pub(in crate::core) struct TaskIter<'p> {
     action_iter: Option<std::slice::Iter<'p, Action>>,
 }
 
-impl<'p> Iterator for TaskIter<'p> {
+impl Iterator for TaskIter<'_> {
     type Item = Arc<HostAction>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/core/plan.rs
+++ b/src/core/plan.rs
@@ -118,7 +118,7 @@ pub struct HostPlanIter<'p> {
     current_iter: Option<TaskIter<'p>>,
 }
 
-impl<'p> Iterator for HostPlanIter<'p> {
+impl Iterator for HostPlanIter<'_> {
     type Item = Arc<HostAction>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -193,7 +193,7 @@ impl Iterator for HostPlanIntoIter {
     }
 }
 
-impl<'p> IntoIterator for HostPlan<'p> {
+impl IntoIterator for HostPlan<'_> {
     type Item = Arc<HostAction>;
     type IntoIter = HostPlanIntoIter;
 


### PR DESCRIPTION
Resolves Clippy lints that I don't recall seeing last time I worked on Sira. I'm always happy to elide a lifetime name if I can.