### PR TITLE
Add full version numbers for dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-home = "0.5"
-indexmap = { version = "2.0", features = ["serde"] }
+anyhow = "1.0.97"
+async-trait = "0.1.88"
+home = "0.5.11"
+indexmap = { version = "2.8.0", features = ["serde"] }
 openssh = { version = "0.10", features = ["native-mux"], optional = true }
-regex = "1.9"
-serde = "1.0"
-serde_yaml = "0.9"
-shlex = "1.3"
-tokio = { version = "1.34", features = ["process", "rt", "rt-multi-thread"], optional = true }
+regex = "1.11.1"
+serde = "1.0.219"
+serde_yaml = "0.9.34"
+shlex = "1.3.0"
+tokio = { version = "1.44.1", features = ["process", "rt", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = "3.19.1"
 
 [features]
 default = ["openssh"]


### PR DESCRIPTION
This brings the dependency list in line with current best practices.

For sanity's sake, I have used the current versions of all dependencies.